### PR TITLE
add zkmr team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 # Primary repo maintainers
 
 -       @Lagrange-Labs/lsc-core-dev
+-       @Lagrange-Labs/distributed-system


### PR DESCRIPTION
## Reviewers

- @Lagrange-Labs/lsc-core-dev 
- @Lagrange-Labs/distributed-system 