### PR TITLE
Fix typos

### DIFF
--- a/docs/state-committees/run-node/commands.md
+++ b/docs/state-committees/run-node/commands.md
@@ -137,7 +137,7 @@ lagrange-cli unsubscribe-chain -c <Config File Path> -n <Network Name> -r <Chain
   - The Beacon RPC endpoint is the Beacon mainnet RPC endpoint for both mainnet and holesky testnet.
 
 :::info
-We recommend using performant providers such Alchemy, Quicknode, Infura, in the case that you do not run your own nodes. Please use appropriate rate limits. For the Beacon RPC endpoint, you should check if the given RPC provider supports the Beacon RPC API like `/eth/v1/beacon/genesis`. Quicknode supports this API.
+We recommend using performant providers such as Alchemy, Quicknode, Infura, in the case that you do not run your own nodes. Please use appropriate rate limits. For the Beacon RPC endpoint, you should check if the given RPC provider supports the Beacon RPC API like `/eth/v1/beacon/genesis`. Quicknode supports this API.
 :::
 
 ```bash

--- a/docs/state-committees/run-node/configuration.md
+++ b/docs/state-committees/run-node/configuration.md
@@ -6,7 +6,7 @@ author: kashish
 ---
 
 :::info
-Please provide correct relative/absolute path in KeystorePath and PasswordPath fields in the configuration file. The KeystorePath field should have file with `.key` extension.
+Please provide the correct relative/absolute path in KeystorePath and PasswordPath fields in the configuration file. The KeystorePath field should have file with `.key` extension.
 :::
 
 ### Variable Description

--- a/docs/state-committees/run-node/monitoring.md
+++ b/docs/state-committees/run-node/monitoring.md
@@ -29,7 +29,7 @@ cd $HOME/.lagrange && docker compose -f <docker-compose-file> down --remove-orph
 
 ## Prometheus Metrics
 
-Lagrange Attestation Nodes exposes prometheus metrics that can be utilized by the operators to monitor the performance of their node. Prometheus metrics client is running on port 8080. There are various labels available which can be used to filter the metrics for a granular view.
+Lagrange Attestation Nodes exposes prometheus metrics that can be utilized by the operators to monitor the performance of their node. Prometheus metrics client is running on port 8080. There are various labels available that can be used to filter the metrics for a granular view.
 
 ### Metrics Description
 

--- a/docs/state-committees/slashing.md
+++ b/docs/state-committees/slashing.md
@@ -5,7 +5,7 @@ description: Slashing conditions for State Committees operators
 author: kashish
 ---
 
-If a cross-chain state attestor executes a signature on an incorrect header or State Committees root for a given block, other network actors must be able to trigger slashing of that node’s collateral. For slashing to occur in a trustless fashion, there must be a deterministic set of conditions under which a signature can be considered incorrect. Verifying the object that a node signed with its BLS key is trivial to do on-chain with a cost of ~110,000 gas.
+If a cross-chain state attestor executes a signature on an incorrect header or State Committee's root for a given block, other network actors must be able to trigger slashing of that node’s collateral. For slashing to occur in a trustless fashion, there must be a deterministic set of conditions under which a signature can be considered incorrect. Verifying the object that a node signed with its BLS key is trivial to do on-chain with a cost of ~110,000 gas.
 
 To prove that a node attested to an incorrect committee root, a proof must show that the root signed by a given node incorrectly includes or excludes a specific public key. As committees are stored in contracts on Ethereum, the required leaf nodes can easily be referenced on-chain as part of proving inclusion or exclusion within a committee root for slashing.
 

--- a/docs/zk-coprocessor/avs-operators/overview.md
+++ b/docs/zk-coprocessor/avs-operators/overview.md
@@ -6,6 +6,6 @@ description: Overview for ZK Coprocessor AVS operators
 
 The Lagrange network is open for operators registered on EigenLayer.
 
-**Role of an operator:** An operator is expected to serve proving requests from Lagrange network by running a "worker" binary. A request is created by the sequencer and contains all the necessary inputs to generate a zkproofs. Overall, a set of proofs are aggregated into a final proof to server a user query.
+**Role of an operator:** An operator is expected to serve proving requests from Lagrange network by running a "worker" binary. A request is created by the sequencer and contains all the necessary inputs to generate a zkproofs. Overall, a set of proofs are aggregated into a final proof to serve a user query.
 
 Currently the proof system used is Plonky2 but a worker is agnostic to the exact semantics and details of what is he proving.

--- a/docs/zk-coprocessor/avs-operators/prerequisites.md
+++ b/docs/zk-coprocessor/avs-operators/prerequisites.md
@@ -35,7 +35,7 @@ We are also running different workers on the cloud. The following table represen
 | large       | 90   | 180 |
 
 :::note
-Given the parallelism of current proof system is not optimal yet (plonky2), it is possible to run 2 worker binaries in the same instance for the moment.
+Given the parallelism of the current proof system is not optimal yet (plonky2), it is possible to run 2 worker binaries in the same instance for the moment.
 :::
 
 ## Installation

--- a/docs/zk-coprocessor/avs-operators/registration.md
+++ b/docs/zk-coprocessor/avs-operators/registration.md
@@ -28,7 +28,7 @@ new Lagrange keystore stored under config/lagr_keystore.json
 
 ## Registration on Lagrange AVS Contract
 
-Now that there is an operator key, the operator needs to register is to the Lagrange Network contracts.
+Now that there is an operator key, the operator needs to register it to the Lagrange Network contracts.
 
 For this, the operator needs to gather both:
 

--- a/docs/zk-coprocessor/avs-operators/stake-and-proofs.md
+++ b/docs/zk-coprocessor/avs-operators/stake-and-proofs.md
@@ -6,8 +6,8 @@ description: A detailed description on the relation between the stake of an oper
 
 This page describes the relation between the stake of an operator and the proof generation tasks it must fulfill.
 
-In Lagrange Network, the stake of an operator is used to guarantee liveness: that when an operator receives a task, it delivers a valid proof within the alloted time. Given the user query relies on these proofs, it is paramount that the Lagrange Network is able to generate proofs as fast as possible.
+In Lagrange Network, the stake of an operator is used to guarantee liveness: that when an operator receives a task, it delivers a valid proof within the allotted time. Given the user query relies on these proofs, it is paramount that the Lagrange Network is able to generate proofs as fast as possible.
 
-A worker that accepts a tasks is "binding" some of its stake to the guarantee of answering back the proof in the alloted time. We can say some of its stake becomes now "active". An operator can take multiple tasks at once, as once as the amount of "active stake" does not grow more than its total stake delegated on the Lagrange Network !
+A worker that accepts a tasks is "binding" some of its stake to the guarantee of answering back the proof in the allotted time. We can say some of its stake becomes now "active". An operator can take multiple tasks at once, as once as the amount of "active stake" does not grow more than its total stake delegated on the Lagrange Network !
 
 It is up to the operator to manage its fleet of workers and decide what type of workers one wants to run. We will provide more guided documentation on that matter in the following weeks. However, given the early phases of the project, we recommend to be running a simple worker to start with and scale up with time.


### PR DESCRIPTION

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.