### PR TITLE
Update contract-addresses.md

### DIFF
--- a/docs/zk-coprocessor/avs-operators/contract-addresses.md
+++ b/docs/zk-coprocessor/avs-operators/contract-addresses.md
@@ -17,4 +17,5 @@ Lagrange ZK Coprocessor is currently deployed on both Holesky and Mainnet networ
 
 | Contract          | Address                                                                                                                       |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| ZKMRServiceManager | [0xf98D5De1014110C65c51b85Ea55f73863215CC10](https://etherscan.io/address/0xf98D5De1014110C65c51b85Ea55f73863215CC10#writeProxyContract) |
 | ZKMRStakeRegistry | [0xf724cDC7C40fd6B59590C624E8F0E5E3843b4BE4](https://holesky.etherscan.io/address/0xf724cDC7C40fd6B59590C624E8F0E5E3843b4BE4) |


### PR DESCRIPTION
Added in Holesky ServiceManager address
Appears in the `worker` binary, but not reflected in the docs

https://github.com/Lagrange-Labs/lgn-coprocessor/blob/52baed18809e35a8df5ef54176adaabf32a6c732/lgn-worker/src/avs/contract.rs#L11

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces. -->

---

## Reviewers

- @Lagrange-Labs/lsc-core-dev
- @Lagrange-Labs/distributed-system
